### PR TITLE
README: update print_help() example condition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,8 +221,8 @@ no options have been matched, you can also do that with ``print_help()``
 
     parser = Transport(sys.argv, check_help=False)
 
-    if parser.has('--verbose'):
-        my_program.verbose()
+    if parser.has('--mandatory-option'):
+        my_program.mandatory_thing()
     else:
         parser.print_help()
 


### PR DESCRIPTION
Consumers will generally want to call `print_help()` only when missing something critical.

`--verbose` is typically an optional argument. Use an important-sounding argument to make the example clearer.