### PR TITLE
cleanup MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ include setup.py
 include README.rst
 include LICENSE
 include distribute_setup.py
-recursive-include tambo/tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include setup.py
 include README.rst
 include LICENSE
-include distribute_setup.py


### PR DESCRIPTION
The 0.4.0 release includes a bad `__pycache__` directory inside the `tests` directory. I think this is a result of the recursive-include in `MANIFEST.in` here.

While we're here, remove the reference to the non-existent `distribute_setup.py` file too.