### PR TITLE
improve pytest import

### DIFF
--- a/tambo/tests/test_parser.py
+++ b/tambo/tests/test_parser.py
@@ -1,4 +1,4 @@
-from py.test import raises
+from pytest import raises
 from tambo import Parse
 import sys
 if sys.version < '3':


### PR DESCRIPTION
Pytest 7.2 no longer depends on the `py` library, so the `py.test` import no longer works in all cases. Import with the standard `pytest` name.

Fixes: #12